### PR TITLE
Support version 5.x of TF AWS provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ module "example" {
 | Name | Version |
 |------|---------|
 | terraform | ~> 1.0 |
-| aws | ~> 4.9 |
+| aws | ~> 5.0 |
 
 ## Providers ##
 
 | Name | Version |
 |------|---------|
-| aws | ~> 4.9 |
-| aws.users | ~> 4.9 |
+| aws | ~> 5.0 |
+| aws.users | ~> 5.0 |
 
 ## Modules ##
 
@@ -61,8 +61,10 @@ No modules.
 | [aws_iam_role_policy_attachment.provisioncdmcloudtrail_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_user_policy_attachment.cdm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_s3_bucket.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_ownership_controls.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_policy.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_sns_topic.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
 | [aws_sns_topic_policy.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_policy) | resource |
 | [aws_sns_topic_subscription.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |

--- a/bucket.tf
+++ b/bucket.tf
@@ -10,11 +10,15 @@ resource "aws_s3_bucket" "cloudtrail" {
   ]
 
   bucket_prefix = var.bucket_prefix
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
+}
+
+# Ensure the S3 bucket is encrypted
+resource "aws_s3_bucket_server_side_encryption_configuration" "cloudtrail" {
+  bucket = aws_s3_bucket.cloudtrail.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
     }
   }
 }

--- a/bucket.tf
+++ b/bucket.tf
@@ -33,6 +33,18 @@ resource "aws_s3_bucket_public_access_block" "cloudtrail" {
   restrict_public_buckets = true
 }
 
+# Any objects placed into this bucket should be owned by the bucket
+# owner. This ensures that even if objects are added by a different
+# account, the bucket-owning account retains full control over the
+# objects stored in this bucket.
+resource "aws_s3_bucket_ownership_controls" "cloudtrail" {
+  bucket = aws_s3_bucket.cloudtrail.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
 # Policy document that allows CloudTrail to write logs to this bucket.
 # See
 # https://docs.aws.amazon.com/awscloudtrail/latest/userguide/create-s3-bucket-policy-for-cloudtrail.html.

--- a/examples/basic_usage/README.md
+++ b/examples/basic_usage/README.md
@@ -13,7 +13,7 @@ Note that this example may create resources which cost money. Run
 | Name | Version |
 |------|---------|
 | terraform | ~> 1.0 |
-| aws | ~> 4.9 |
+| aws | ~> 5.0 |
 
 ## Providers ##
 

--- a/examples/basic_usage/versions.tf
+++ b/examples/basic_usage/versions.tf
@@ -17,7 +17,7 @@ terraform {
     # for more information about the S3 bucket refactor.
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.9"
+      version = "~> 5.0"
     }
   }
 }

--- a/examples/basic_usage/versions.tf
+++ b/examples/basic_usage/versions.tf
@@ -6,15 +6,6 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    # Version 4.9 of the Terraform AWS provider made changes to the S3 bucket
-    # refactor that is in place for versions 4.0-4.8 of the provider. With v4.9
-    # only non-breaking changes and deprecation notices are introduced. Using
-    # this version will simplify migration to the new, broken out AWS S3 bucket
-    # configuration resources. Please see
-    # https://github.com/hashicorp/terraform-provider-aws/pull/23985
-    # for more information about the changes in v4.9 and
-    # https://www.hashicorp.com/blog/terraform-aws-provider-4-0-refactors-s3-bucket-resource
-    # for more information about the S3 bucket refactor.
     aws = {
       source  = "hashicorp/aws"
       version = "~> 5.0"

--- a/versions.tf
+++ b/versions.tf
@@ -6,18 +6,15 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    # Version 4.9 of the Terraform AWS provider made changes to the S3 bucket
-    # refactor that is in place for versions 4.0-4.8 of the provider. With v4.9
-    # only non-breaking changes and deprecation notices are introduced. Using
-    # this version will simplify migration to the new, broken out AWS S3 bucket
-    # configuration resources. Please see
-    # https://github.com/hashicorp/terraform-provider-aws/pull/23985
-    # for more information about the changes in v4.9 and
-    # https://www.hashicorp.com/blog/terraform-aws-provider-4-0-refactors-s3-bucket-resource
-    # for more information about the S3 bucket refactor.
+    # This module is used by cisagov/cool-sharedservices-cdm, which requires
+    # version 5.x of the AWS provider in order to use the "Decompression"
+    # processor in the aws_kinesis_firehose_delivery_stream resource (part of
+    # the extended_s3_configuration).
+    # This comment should be removed when all of our Terraform modules have
+    # migrated to version 5.x.
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.9"
+      version = "~> 5.0"
     }
   }
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR updates this module to use version 5.x of the AWS Terraform provider.

It also updates some deprecated syntax around S3 encryption and adds our standard S3 bucket ownership configuration.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

While this change is eventually needed for all of our Terraform modules in order to stay current, it is more urgently needed in this module because https://github.com/cisagov/cool-sharedservices-cdm/pull/46 requires provider version 5.x to support the [gzip decompression processor in the `aws_kinesis_firehose_delivery_stream` resource](https://github.com/cisagov/cool-sharedservices-cdm/pull/46/commits/3432d771de89ad7c23385d5881fe9039642dc7f3).  Since `cisagov/cool-sharedservices-cdm` is dependent on this module, both modules must be upgraded to version 5.x of the AWS provider.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

This code has been successfully applied as part of the testing of https://github.com/cisagov/cool-sharedservices-cdm/pull/46.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
